### PR TITLE
Output the summary in the same order as the topological sort 

### DIFF
--- a/astrid.py
+++ b/astrid.py
@@ -94,10 +94,10 @@ def create_matrix(data):
     return matrix
 
 
-def print_summary(jobids):
+def print_summary(jobids, ts):
     print('\n' + 'Job name'.ljust(20), 'Job ID')
     print('-' * 34)
-    for item in jobids:
+    for item in ts:
         print(item.ljust(20), jobids[item])
     return
 
@@ -119,7 +119,7 @@ def astrid(args):
         time.sleep(args.delay)
 
     print('\nAll jobs submitted!')
-    print_summary(jobids)
+    print_summary(jobids, ts)
 
 
 def create_parser():


### PR DESCRIPTION
And so the job IDs will be increasing. This neatens up the output, and stops the output relying on the (not guaranteed) order of output of the dictionary.